### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node tunneler.js"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/hyperstore2020/tunnelerjs)](https://repl.it/github/hyperstore2020/tunnelerjs)
+
 NOTE: at this point of development this bot is suitable only for experienced users. Some of the documentation below may be deprecated or otherwise lacking.
 
 # tunnelerjs


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).